### PR TITLE
Add offline Pomodoro study tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-# teoproject
+# Pomodoro Timer with Goal and Statistics Tracking
+
+A cross-platform Java console application built to help students such as Gleb stay focused during
+study sessions. The tool implements the Pomodoro technique, stores progress across sessions, and
+shows weekly productivity statistics without requiring an internet connection.
+
+## Features
+
+- Configure a custom study goal before each session, including a description and optional target
+  duration in minutes.
+- Adjustable Pomodoro timings: choose the length of focus intervals, break durations, and the number
+  of intervals per session.
+- Real-time session controls (pause, resume, status, reset) that keep the timer running while you
+  interact with the console.
+- Automatic logging of every session (date, focus minutes, intervals completed) to a local CSV file
+  so progress is preserved between runs.
+- Weekly statistics that summarise total study time, sessions completed, and Pomodoro intervals
+  achieved to provide feedback on study habits.
+
+All functionality works entirely offline so there are no distractions from internet-connected apps.
+
+## Getting Started
+
+1. Ensure you have Java 17 or later installed.
+2. Compile the project:
+
+   ```bash
+   mkdir -p out
+   javac $(find src/main/java -name "*.java") -d out
+   ```
+
+3. Run the application:
+
+   ```bash
+   java -cp out com.teoproject.pomodoro.PomodoroApp
+   ```
+
+4. Follow the on-screen menu to set a study goal, adjust timings, start a session, and review weekly
+   statistics.
+
+Session logs are saved to `session_log.csv` in the project directory. You can back up or analyse this
+file to review long-term trends.
+
+## Project Structure
+
+```
+src/main/java/com/teoproject/pomodoro/
+├── PomodoroApp.java           # Console interface and application entry point
+├── PomodoroConfiguration.java # Stores goal and timer settings
+├── PomodoroTimer.java         # Manages Pomodoro timing logic and commands
+├── SessionLogEntry.java       # Represents persisted study sessions
+├── SessionLogger.java         # Reads/writes session logs to disk
+└── StatisticsCalculator.java  # Calculates weekly study statistics
+```
+
+Feel free to adapt the timings and workflow to suit different study routines or to add a graphical
+interface in the future.

--- a/src/main/java/com/teoproject/pomodoro/PomodoroApp.java
+++ b/src/main/java/com/teoproject/pomodoro/PomodoroApp.java
@@ -1,0 +1,270 @@
+package com.teoproject.pomodoro;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Scanner;
+
+/**
+ * Entry point for the Pomodoro study application. Provides a simple console interface for
+ * configuring study goals, running timed sessions, and reviewing productivity statistics.
+ */
+public class PomodoroApp {
+
+    private final Scanner scanner = new Scanner(System.in);
+    private final PomodoroConfiguration configuration = new PomodoroConfiguration();
+    private final SessionLogger sessionLogger = new SessionLogger();
+    private final StatisticsCalculator statisticsCalculator = new StatisticsCalculator();
+
+    public static void main(String[] args) {
+        PomodoroApp app = new PomodoroApp();
+        app.run();
+    }
+
+    private void run() {
+        System.out.println("Pomodoro Timer with Goal and Statistics Tracking");
+        System.out.println("==================================================");
+        boolean running = true;
+        while (running) {
+            showMainMenu();
+            String choice = scanner.nextLine().trim();
+            switch (choice) {
+                case "1" -> configureStudyGoal();
+                case "2" -> configurePomodoroSettings();
+                case "3" -> startPomodoroSession();
+                case "4" -> displayWeeklyStatistics();
+                case "5" -> {
+                    running = false;
+                    System.out.println("Good luck with your studies!");
+                }
+                default -> System.out.println("Please enter a valid option (1-5).");
+            }
+        }
+    }
+
+    private void showMainMenu() {
+        System.out.println();
+        System.out.println("Main Menu");
+        System.out.println("---------");
+        System.out.println("1. Set study goal");
+        System.out.println("2. Configure Pomodoro timings");
+        System.out.println("3. Start study session");
+        System.out.println("4. View weekly statistics");
+        System.out.println("5. Exit");
+        System.out.print("Select an option: ");
+    }
+
+    private void configureStudyGoal() {
+        System.out.println();
+        System.out.println("Set Study Goal");
+        System.out.println("---------------");
+        System.out.print("Enter your goal description (e.g. 'Two hours of maths revision'): ");
+        String goal = scanner.nextLine().trim();
+        while (goal.isBlank()) {
+            System.out.print("The goal description cannot be empty. Please enter a description: ");
+            goal = scanner.nextLine().trim();
+        }
+        configuration.setGoalDescription(goal);
+
+        int minutes = readNonNegativeInt("Enter the number of minutes you aim to study this session (0 to skip): ", true);
+        configuration.setGoalTargetMinutes(minutes);
+        System.out.println("Goal saved: " + goal + (minutes > 0 ? " (" + minutes + " minutes)" : ""));
+    }
+
+    private void configurePomodoroSettings() {
+        System.out.println();
+        System.out.println("Configure Pomodoro Timings");
+        System.out.println("---------------------------");
+        System.out.println("Press Enter to keep the current value.");
+
+        int work = readOptionalInt(
+                "Work interval length in minutes [current: " + configuration.getWorkDurationMinutes() + "]: ",
+                configuration.getWorkDurationMinutes(), 1);
+        configuration.setWorkDurationMinutes(work);
+
+        int rest = readOptionalInt(
+                "Break interval length in minutes [current: " + configuration.getBreakDurationMinutes() + "]: ",
+                configuration.getBreakDurationMinutes(), 0);
+        configuration.setBreakDurationMinutes(rest);
+
+        int intervals = readOptionalInt(
+                "Number of focus intervals per session [current: " + configuration.getIntervalsPerSession() + "]: ",
+                configuration.getIntervalsPerSession(), 1);
+        configuration.setIntervalsPerSession(intervals);
+
+        System.out.println("Updated Pomodoro settings saved.");
+    }
+
+    private void startPomodoroSession() {
+        if (configuration.getGoalDescription().isBlank()) {
+            System.out.println("Please set a study goal before starting a session (option 1).");
+            return;
+        }
+
+        System.out.println();
+        System.out.println("Starting Pomodoro session for goal: " + configuration.getGoalDescription());
+        if (configuration.getGoalTargetMinutes() > 0) {
+            System.out.println("Target study minutes for this session: " + configuration.getGoalTargetMinutes());
+        }
+        System.out.println("Each focus interval lasts " + configuration.getWorkDurationMinutes() + " minutes with "
+                + configuration.getBreakDurationMinutes() + " minute breaks.");
+        System.out.println("Total intervals this session: " + configuration.getIntervalsPerSession());
+
+        PomodoroTimer timer = new PomodoroTimer(
+                configuration.getWorkDurationMinutes(),
+                configuration.getBreakDurationMinutes(),
+                configuration.getIntervalsPerSession());
+        Thread timerThread = new Thread(timer, "Pomodoro-Timer");
+        timerThread.start();
+
+        boolean sessionStoppedByUser = handleSessionCommands(timer);
+        try {
+            timerThread.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            System.err.println("Timer thread was interrupted.");
+        }
+
+        PomodoroTimer.TimerStatus status = timer.getStatus();
+        long focusMinutes = Math.round(timer.getTotalFocusSeconds() / 60.0);
+        if (timer.getTotalFocusSeconds() > 0) {
+            try {
+                sessionLogger.appendEntry(configuration.getGoalDescription(), focusMinutes, timer.getCompletedIntervals());
+                System.out.println("Session details saved to log file at " + sessionLogger.getLogPath().toAbsolutePath());
+            } catch (IOException e) {
+                System.err.println("Failed to write session log: " + e.getMessage());
+            }
+        }
+
+        if (timer.isCompleted()) {
+            System.out.println("Congratulations! You completed all " + timer.getIntervalsPerSession() + " intervals.");
+        } else if (sessionStoppedByUser) {
+            System.out.println("Session stopped early. Completed intervals: " + timer.getCompletedIntervals());
+        } else {
+            System.out.println("Session ended unexpectedly.");
+        }
+    }
+
+    private boolean handleSessionCommands(PomodoroTimer timer) {
+        System.out.println();
+        System.out.println("Session running. Enter commands as needed:");
+        System.out.println(" - pause: pause the current interval");
+        System.out.println(" - resume: resume a paused interval");
+        System.out.println(" - status: show the time remaining and progress");
+        System.out.println(" - reset: stop the session early");
+        System.out.println(" - exit: stop the session early and return to menu");
+        boolean stoppedByUser = false;
+
+        while (timer.isRunning()) {
+            System.out.print("Command> ");
+            String input;
+            try {
+                input = scanner.nextLine().trim().toLowerCase();
+            } catch (Exception ex) {
+                timer.requestStop();
+                break;
+            }
+            switch (input) {
+                case "pause" -> {
+                    timer.pause();
+                    System.out.println("Timer paused.");
+                }
+                case "resume" -> {
+                    timer.resume();
+                    System.out.println("Timer resumed.");
+                }
+                case "status" -> printStatus(timer);
+                case "reset", "exit", "stop" -> {
+                    timer.requestStop();
+                    stoppedByUser = true;
+                }
+                case "" -> printStatus(timer);
+                default -> System.out.println("Unknown command. Try pause, resume, status, or reset.");
+            }
+        }
+
+        return stoppedByUser;
+    }
+
+    private void printStatus(PomodoroTimer timer) {
+        PomodoroTimer.TimerStatus status = timer.getStatus();
+        String phase = switch (status.getPhase()) {
+            case WORK -> "Focus";
+            case BREAK -> "Break";
+            case COMPLETE -> "Complete";
+            case IDLE -> "Idle";
+        };
+        long minutes = status.getRemaining().toMinutes();
+        long seconds = status.getRemaining().minusMinutes(minutes).getSeconds();
+        System.out.printf("Phase: %s | Time remaining: %02d:%02d | Intervals: %d/%d%s%n",
+                phase,
+                minutes,
+                seconds,
+                status.getCompletedIntervals(),
+                status.getIntervalsPerSession(),
+                status.isPaused() ? " (paused)" : "");
+    }
+
+    private void displayWeeklyStatistics() {
+        System.out.println();
+        System.out.println("Weekly Statistics");
+        System.out.println("-----------------");
+        try {
+            List<SessionLogEntry> entries = sessionLogger.readAllEntries();
+            StatisticsCalculator.WeeklyStatistics stats = statisticsCalculator.calculateWeeklyStatistics(entries, LocalDate.now());
+            System.out.printf("Sessions completed this week: %d%n", stats.getSessionsCompleted());
+            System.out.printf("Total focus time this week: %.2f hours (%d minutes)%n", stats.getTotalHours(), stats.getTotalMinutes());
+            System.out.printf("Intervals completed this week: %d%n", stats.getIntervalsCompleted());
+            if (configuration.getGoalTargetMinutes() > 0) {
+                double progress = stats.getTotalMinutes() / (double) configuration.getGoalTargetMinutes() * 100;
+                System.out.printf("Progress toward current goal: %.1f%%%n", progress);
+            }
+        } catch (IOException e) {
+            System.err.println("Could not read session log: " + e.getMessage());
+        }
+    }
+
+    private int readNonNegativeInt(String prompt, boolean allowZero) {
+        while (true) {
+            System.out.print(prompt);
+            String input = scanner.nextLine().trim();
+            if (input.isBlank()) {
+                if (allowZero) {
+                    return 0;
+                }
+                System.out.println("Value is required. Please enter a number.");
+                continue;
+            }
+            try {
+                int value = Integer.parseInt(input);
+                if (value < 0 || (!allowZero && value == 0)) {
+                    System.out.println("Please enter a positive number.");
+                } else {
+                    return value;
+                }
+            } catch (NumberFormatException e) {
+                System.out.println("Invalid number. Try again.");
+            }
+        }
+    }
+
+    private int readOptionalInt(String prompt, int currentValue, int minimum) {
+        while (true) {
+            System.out.print(prompt);
+            String input = scanner.nextLine().trim();
+            if (input.isBlank()) {
+                return currentValue;
+            }
+            try {
+                int value = Integer.parseInt(input);
+                if (value < minimum) {
+                    System.out.println("Please enter a number greater than or equal to " + minimum + ".");
+                } else {
+                    return value;
+                }
+            } catch (NumberFormatException e) {
+                System.out.println("Invalid number. Try again.");
+            }
+        }
+    }
+}

--- a/src/main/java/com/teoproject/pomodoro/PomodoroConfiguration.java
+++ b/src/main/java/com/teoproject/pomodoro/PomodoroConfiguration.java
@@ -1,0 +1,64 @@
+package com.teoproject.pomodoro;
+
+/**
+ * Holds configurable values for a Pomodoro study session.
+ */
+public class PomodoroConfiguration {
+    private String goalDescription = "";
+    private int workDurationMinutes = 25;
+    private int breakDurationMinutes = 5;
+    private int intervalsPerSession = 4;
+    private int goalTargetMinutes = 0;
+
+    public String getGoalDescription() {
+        return goalDescription;
+    }
+
+    public void setGoalDescription(String goalDescription) {
+        this.goalDescription = goalDescription;
+    }
+
+    public int getWorkDurationMinutes() {
+        return workDurationMinutes;
+    }
+
+    public void setWorkDurationMinutes(int workDurationMinutes) {
+        if (workDurationMinutes <= 0) {
+            throw new IllegalArgumentException("Work duration must be positive.");
+        }
+        this.workDurationMinutes = workDurationMinutes;
+    }
+
+    public int getBreakDurationMinutes() {
+        return breakDurationMinutes;
+    }
+
+    public void setBreakDurationMinutes(int breakDurationMinutes) {
+        if (breakDurationMinutes < 0) {
+            throw new IllegalArgumentException("Break duration cannot be negative.");
+        }
+        this.breakDurationMinutes = breakDurationMinutes;
+    }
+
+    public int getIntervalsPerSession() {
+        return intervalsPerSession;
+    }
+
+    public void setIntervalsPerSession(int intervalsPerSession) {
+        if (intervalsPerSession <= 0) {
+            throw new IllegalArgumentException("Intervals per session must be positive.");
+        }
+        this.intervalsPerSession = intervalsPerSession;
+    }
+
+    public int getGoalTargetMinutes() {
+        return goalTargetMinutes;
+    }
+
+    public void setGoalTargetMinutes(int goalTargetMinutes) {
+        if (goalTargetMinutes < 0) {
+            throw new IllegalArgumentException("Goal target minutes cannot be negative.");
+        }
+        this.goalTargetMinutes = goalTargetMinutes;
+    }
+}

--- a/src/main/java/com/teoproject/pomodoro/PomodoroTimer.java
+++ b/src/main/java/com/teoproject/pomodoro/PomodoroTimer.java
@@ -1,0 +1,229 @@
+package com.teoproject.pomodoro;
+
+import java.time.Duration;
+
+/**
+ * Controls the execution of a Pomodoro session by managing alternating work and break periods.
+ * The timer runs on its own thread so the user interface can issue commands such as pause, resume,
+ * and reset while a session is active.
+ */
+public class PomodoroTimer implements Runnable {
+    public enum Phase {
+        WORK,
+        BREAK,
+        COMPLETE,
+        IDLE
+    }
+
+    private final Object lock = new Object();
+    private final int workDurationMinutes;
+    private final int breakDurationMinutes;
+    private final int intervalsPerSession;
+
+    private volatile boolean running;
+    private volatile boolean paused;
+    private volatile boolean stopRequested;
+    private volatile boolean completed;
+
+    private Phase currentPhase = Phase.IDLE;
+    private int remainingSeconds;
+    private int completedIntervals;
+    private long totalFocusSeconds;
+
+    public PomodoroTimer(int workDurationMinutes, int breakDurationMinutes, int intervalsPerSession) {
+        this.workDurationMinutes = workDurationMinutes;
+        this.breakDurationMinutes = breakDurationMinutes;
+        this.intervalsPerSession = intervalsPerSession;
+    }
+
+    @Override
+    public void run() {
+        running = true;
+        stopRequested = false;
+        completed = false;
+        completedIntervals = 0;
+        totalFocusSeconds = 0;
+
+        try {
+            for (int i = 0; i < intervalsPerSession && !stopRequested; i++) {
+                if (!runPhase(workDurationMinutes * 60, Phase.WORK)) {
+                    finish(false);
+                    return;
+                }
+
+                if (stopRequested) {
+                    finish(false);
+                    return;
+                }
+
+                if (i < intervalsPerSession - 1) {
+                    if (!runPhase(breakDurationMinutes * 60, Phase.BREAK)) {
+                        finish(false);
+                        return;
+                    }
+                }
+            }
+        } finally {
+            if (!stopRequested && completedIntervals == intervalsPerSession) {
+                finish(true);
+            } else if (stopRequested) {
+                finish(false);
+            }
+        }
+    }
+
+    private boolean runPhase(int totalSeconds, Phase phase) {
+        synchronized (lock) {
+            currentPhase = phase;
+            remainingSeconds = totalSeconds;
+        }
+
+        while (remainingSeconds > 0) {
+            synchronized (lock) {
+                if (stopRequested) {
+                    return false;
+                }
+                while (paused && !stopRequested) {
+                    try {
+                        lock.wait();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return false;
+                    }
+                }
+                if (stopRequested) {
+                    return false;
+                }
+            }
+
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+
+            synchronized (lock) {
+                remainingSeconds--;
+                if (phase == Phase.WORK) {
+                    totalFocusSeconds++;
+                }
+            }
+        }
+
+        if (phase == Phase.WORK) {
+            completedIntervals++;
+        }
+
+        return true;
+    }
+
+    private void finish(boolean wasCompleted) {
+        synchronized (lock) {
+            running = false;
+            paused = false;
+            completed = wasCompleted;
+            currentPhase = Phase.COMPLETE;
+            remainingSeconds = 0;
+            lock.notifyAll();
+        }
+    }
+
+    public void pause() {
+        synchronized (lock) {
+            if (running && !paused) {
+                paused = true;
+            }
+        }
+    }
+
+    public void resume() {
+        synchronized (lock) {
+            if (running && paused) {
+                paused = false;
+                lock.notifyAll();
+            }
+        }
+    }
+
+    public void requestStop() {
+        synchronized (lock) {
+            stopRequested = true;
+            paused = false;
+            lock.notifyAll();
+        }
+    }
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    public boolean isPaused() {
+        return paused;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public TimerStatus getStatus() {
+        synchronized (lock) {
+            Duration remaining = Duration.ofSeconds(Math.max(0, remainingSeconds));
+            return new TimerStatus(currentPhase, remaining, completedIntervals, intervalsPerSession, paused);
+        }
+    }
+
+    public int getCompletedIntervals() {
+        return completedIntervals;
+    }
+
+    public long getTotalFocusSeconds() {
+        return totalFocusSeconds;
+    }
+
+    public int getIntervalsPerSession() {
+        return intervalsPerSession;
+    }
+
+    public enum PhaseStatus {
+        ACTIVE,
+        PAUSED,
+        COMPLETE
+    }
+
+    public static class TimerStatus {
+        private final Phase phase;
+        private final Duration remaining;
+        private final int completedIntervals;
+        private final int intervalsPerSession;
+        private final boolean paused;
+
+        public TimerStatus(Phase phase, Duration remaining, int completedIntervals, int intervalsPerSession, boolean paused) {
+            this.phase = phase;
+            this.remaining = remaining;
+            this.completedIntervals = completedIntervals;
+            this.intervalsPerSession = intervalsPerSession;
+            this.paused = paused;
+        }
+
+        public Phase getPhase() {
+            return phase;
+        }
+
+        public Duration getRemaining() {
+            return remaining;
+        }
+
+        public int getCompletedIntervals() {
+            return completedIntervals;
+        }
+
+        public int getIntervalsPerSession() {
+            return intervalsPerSession;
+        }
+
+        public boolean isPaused() {
+            return paused;
+        }
+    }
+}

--- a/src/main/java/com/teoproject/pomodoro/SessionLogEntry.java
+++ b/src/main/java/com/teoproject/pomodoro/SessionLogEntry.java
@@ -1,0 +1,100 @@
+package com.teoproject.pomodoro;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Represents a single study session entry stored in the persistent log file.
+ */
+public class SessionLogEntry {
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    private final LocalDateTime timestamp;
+    private final String goalDescription;
+    private final long focusMinutes;
+    private final int intervalsCompleted;
+
+    public SessionLogEntry(LocalDateTime timestamp, String goalDescription, long focusMinutes, int intervalsCompleted) {
+        this.timestamp = timestamp;
+        this.goalDescription = goalDescription;
+        this.focusMinutes = focusMinutes;
+        this.intervalsCompleted = intervalsCompleted;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public String getGoalDescription() {
+        return goalDescription;
+    }
+
+    public long getFocusMinutes() {
+        return focusMinutes;
+    }
+
+    public int getIntervalsCompleted() {
+        return intervalsCompleted;
+    }
+
+    public String toCsvRow() {
+        return String.join(",",
+                FORMATTER.format(timestamp),
+                escape(goalDescription),
+                Long.toString(focusMinutes),
+                Integer.toString(intervalsCompleted));
+    }
+
+    public static SessionLogEntry fromCsvRow(String row) {
+        String[] parts = splitEscaped(row);
+        if (parts.length < 4) {
+            throw new IllegalArgumentException("Invalid log row: " + row);
+        }
+        LocalDateTime time = LocalDateTime.parse(parts[0], FORMATTER);
+        String goal = unescape(parts[1]);
+        long minutes = Long.parseLong(parts[2]);
+        int intervals = Integer.parseInt(parts[3]);
+        return new SessionLogEntry(time, goal, minutes, intervals);
+    }
+
+    private static String escape(String text) {
+        return text.replace("\\", "\\\\").replace(",", "\\,");
+    }
+
+    private static String unescape(String text) {
+        StringBuilder builder = new StringBuilder();
+        boolean escaping = false;
+        for (char ch : text.toCharArray()) {
+            if (escaping) {
+                builder.append(ch);
+                escaping = false;
+            } else if (ch == '\\') {
+                escaping = true;
+            } else {
+                builder.append(ch);
+            }
+        }
+        return builder.toString();
+    }
+
+    private static String[] splitEscaped(String row) {
+        java.util.List<String> parts = new java.util.ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean escaping = false;
+        for (char ch : row.toCharArray()) {
+            if (escaping) {
+                current.append(ch);
+                escaping = false;
+            } else if (ch == '\\') {
+                escaping = true;
+            } else if (ch == ',') {
+                parts.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(ch);
+            }
+        }
+        parts.add(current.toString());
+        return parts.toArray(new String[0]);
+    }
+}

--- a/src/main/java/com/teoproject/pomodoro/SessionLogger.java
+++ b/src/main/java/com/teoproject/pomodoro/SessionLogger.java
@@ -1,0 +1,62 @@
+package com.teoproject.pomodoro;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Handles persistence of session data to a CSV log file and provides utilities for reading the file.
+ */
+public class SessionLogger {
+    private static final String DEFAULT_LOG_PATH = "session_log.csv";
+
+    private final Path logPath;
+
+    public SessionLogger() {
+        this(DEFAULT_LOG_PATH);
+    }
+
+    public SessionLogger(String path) {
+        this.logPath = Paths.get(path);
+    }
+
+    public synchronized void appendEntry(String goalDescription, long focusMinutes, int intervalsCompleted) throws IOException {
+        ensureFileExists();
+        SessionLogEntry entry = new SessionLogEntry(LocalDateTime.now(), goalDescription, focusMinutes, intervalsCompleted);
+        try (BufferedWriter writer = Files.newBufferedWriter(logPath, StandardCharsets.UTF_8, java.nio.file.StandardOpenOption.APPEND)) {
+            writer.write(entry.toCsvRow());
+            writer.newLine();
+        }
+    }
+
+    public synchronized List<SessionLogEntry> readAllEntries() throws IOException {
+        ensureFileExists();
+        List<SessionLogEntry> entries = new ArrayList<>();
+        for (String line : Files.readAllLines(logPath, StandardCharsets.UTF_8)) {
+            if (!line.isBlank()) {
+                try {
+                    entries.add(SessionLogEntry.fromCsvRow(line));
+                } catch (IllegalArgumentException ex) {
+                    System.err.println("Skipping invalid log line: " + line);
+                }
+            }
+        }
+        return entries;
+    }
+
+    private void ensureFileExists() throws IOException {
+        if (!Files.exists(logPath)) {
+            Files.createFile(logPath);
+        }
+    }
+
+    public Path getLogPath() {
+        return logPath;
+    }
+}

--- a/src/main/java/com/teoproject/pomodoro/StatisticsCalculator.java
+++ b/src/main/java/com/teoproject/pomodoro/StatisticsCalculator.java
@@ -1,0 +1,63 @@
+package com.teoproject.pomodoro;
+
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Provides utility methods for calculating study statistics from stored sessions.
+ */
+public class StatisticsCalculator {
+
+    public WeeklyStatistics calculateWeeklyStatistics(List<SessionLogEntry> entries, LocalDate referenceDate) {
+        WeekFields weekFields = WeekFields.of(Locale.getDefault());
+        int targetWeek = referenceDate.get(weekFields.weekOfWeekBasedYear());
+        int targetYear = referenceDate.get(weekFields.weekBasedYear());
+
+        long totalMinutes = 0;
+        int sessions = 0;
+        int intervals = 0;
+
+        for (SessionLogEntry entry : entries) {
+            LocalDate entryDate = entry.getTimestamp().toLocalDate();
+            int entryWeek = entryDate.get(weekFields.weekOfWeekBasedYear());
+            int entryYear = entryDate.get(weekFields.weekBasedYear());
+            if (entryWeek == targetWeek && entryYear == targetYear) {
+                totalMinutes += entry.getFocusMinutes();
+                sessions++;
+                intervals += entry.getIntervalsCompleted();
+            }
+        }
+
+        return new WeeklyStatistics(totalMinutes, sessions, intervals);
+    }
+
+    public static class WeeklyStatistics {
+        private final long totalMinutes;
+        private final int sessionsCompleted;
+        private final int intervalsCompleted;
+
+        public WeeklyStatistics(long totalMinutes, int sessionsCompleted, int intervalsCompleted) {
+            this.totalMinutes = totalMinutes;
+            this.sessionsCompleted = sessionsCompleted;
+            this.intervalsCompleted = intervalsCompleted;
+        }
+
+        public long getTotalMinutes() {
+            return totalMinutes;
+        }
+
+        public double getTotalHours() {
+            return totalMinutes / 60.0;
+        }
+
+        public int getSessionsCompleted() {
+            return sessionsCompleted;
+        }
+
+        public int getIntervalsCompleted() {
+            return intervalsCompleted;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a console-based Pomodoro application that lets students set study goals and run controllable focus sessions
- persist completed sessions to disk and provide weekly statistics utilities for tracking progress
- document build and execution steps in the README

## Testing
- `javac $(find src/main/java -name "*.java") -d out`


------
https://chatgpt.com/codex/tasks/task_e_68e2f1fa7b3083328603b373b4701604